### PR TITLE
BAU: Add file parameter to generate-env script and make variables explicit in env.sh

### DIFF
--- a/config/env.sh
+++ b/config/env.sh
@@ -1,5 +1,5 @@
 export METADATA_PORT=55500
-export METADATA_URL=http://localhost:${METADATA_PORT}/dev.xml
+export METADATA_URL=http://localhost:55000/dev.xml
 
 export POLICY_PORT=50110
 export CONFIG_PORT=50240
@@ -12,6 +12,6 @@ export TEST_RP_PORT=50130
 export STUB_IDP_PORT=50140
 export VERIFY_FRONTEND_API_PORT=50190
 export COMPLIANCE_TOOL_PORT=50270
-export FRONTEND_PORT=50300
 
-export FRONTEND_URI=http://localhost:$FRONTEND_PORT
+export FRONTEND_PORT=50300
+export FRONTEND_URI=http://localhost:50300

--- a/generate-env.sh
+++ b/generate-env.sh
@@ -1,10 +1,18 @@
 #!/usr/bin/env bash
 set -e
 
+if test "$#" == "0"; then
+  echo "Invalid program arguments:"
+  echo "Valid arguments are --help/-h or path to a file to save the generated .env file to"
+  exit
+fi
+
 if [ "$1" == "-h" ] || [ "$1" == "--help" ] ; then
     echo "Generates the required environment variables for running verify apps"
-    echo "Run ./generate-env.sh > \$app_directory/local.env to configure each app" 
+    echo "Run ./generate-env.sh \$app_directory/local.env to configure each app" 
     exit 0
+else
+    file="$1"
 fi
 
 if test ! -d data; then
@@ -13,10 +21,10 @@ if test ! -d data; then
 fi
 
 ### PORTS
-cat config/env.sh
+cat config/env.sh > "$file"
 
 ### MSA
-cat <<EOF
+cat <<EOF >> "$file"
 export HUB_TRUST_STORE=$(base64 data/pki/hub.ts)
 export METADATA_TRUST_STORE=$(base64 data/pki/metadata.ts)
 export MSA_SIGNING_KEY_PRIMARY=$(base64 data/pki/sample_rp_msa_signing_primary.pk8)
@@ -26,3 +34,5 @@ export MSA_SIGNING_CERT_SECONDARY=$(base64 data/pki/sample_rp_msa_signing_second
 export MSA_ENCRYPTION_KEY_PRIMARY=$(base64 data/pki/sample_rp_msa_encryption_primary.pk8)
 export MSA_ENCRYPTION_CERT_PRIMARY=$(base64 data/pki/sample_rp_msa_encryption_primary.crt)
 EOF
+
+echo "Wrote environment to $file"

--- a/generate/hub-dev-pki.sh
+++ b/generate/hub-dev-pki.sh
@@ -14,6 +14,7 @@ EOF
 tput sgr0
 
 script_dir="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
+source "$script_dir"/../config/env.sh
 data_dir="$script_dir/../data"
 
 mkdir -p "$data_dir"


### PR DESCRIPTION
Added a file parameter instead of piping so that when script has to generate PKI
first it does not get piped into local.env file.
Made variables explicit in env.sh so that they can be easily formatted for IntelliJ
Sourced config/env.sh in generate scripts to fix FRONTEND_URI key error

Authors: @andy-paine