### PR TITLE
bau: fix newer versions of cfssl

### DIFF
--- a/generate/cfssl-config.json
+++ b/generate/cfssl-config.json
@@ -18,7 +18,10 @@
                     "crl sign"
                 ],
                 "expiry": "876000h",
-                "is_ca": true
+                "is_ca": true,
+                "ca_constraint": {
+                    "is_ca": true
+                }
             },
             "signing": {
                 "usages": [


### PR DESCRIPTION
The is_ca option has changed in newer versions of cfssl than available
in homebrew.  If one follows the instructions in the cfssl wiki to get
the latest version, it cannot generate ocsp responses using this json.
This commit leaves the now ignored deprecated option present and adds
in the replacement.  Tested on macos with both options and it still
works correctly.

The new option is here:
https://github.com/cloudflare/cfssl/blob/d2393674072314fda47d2c7c16cb7fd4cdc16821/doc/cmd/cfssl.txt#L124

A clue for this fix was found here:
https://github.com/cloudflare/cfssl/issues/652#issuecomment-236369401

Pair: WillPa