### PR TITLE
BAU: Use the local signed trust anchor file in verify-metadata

### DIFF
--- a/config/ports.env
+++ b/config/ports.env
@@ -20,6 +20,4 @@ STUB_IDP_URI=http://localhost:50140
 TEST_RP_URI=http://localhost:50130
 
 HUB_CONNECTOR_ENTITY_ID="http://localhost:55000/local-connector/metadata.xml"
-COUNTRY_METADATA_URI="http://localhost:56002/ServiceMetadata"
-COUNTRY_EXPECTED_ENTITY_ID="http://localhost:56002/ServiceMetadata"
-TRUST_ANCHOR_URI="http://localhost:55500/local_trust_anchor_signed"
+TRUST_ANCHOR_URI="http://localhost:55000/local/trust-anchor.jws"


### PR DESCRIPTION
Now that we have added the config for generating the signed trust anchor file (see [this PR](https://github.com/alphagov/verify-metadata/pull/69). 

The signed trust anchor for running local stuff are now served up automatically. 

I also cleaned up the environment variables that we no longer use.