### PR TITLE
BAU: Add trustStore.path and its password

### DIFF
--- a/configuration/hub/saml-engine.yml
+++ b/configuration/hub/saml-engine.yml
@@ -82,6 +82,9 @@ metadata:
   uri: ${METADATA_URL:-http://localhost:55000/metadata.xml}
   trustStorePath: data/pki/metadata.ts
   trustStorePassword: marshmallow
+  trustStore:
+    path: data/pki/metadata.ts
+    password: marshmallow
   minRefreshDelay: 60000
   maxRefreshDelay: 600000
   expectedEntityId: https://dev-hub.local

--- a/configuration/hub/saml-proxy.yml
+++ b/configuration/hub/saml-proxy.yml
@@ -56,6 +56,9 @@ metadata:
   uri: ${METADATA_URL:-http://localhost:55000/metadata.xml}
   trustStorePath: data/pki/metadata.ts
   trustStorePassword: marshmallow
+  trustStore:
+    path: data/pki/metadata.ts
+    password: marshmallow
   minRefreshDelay: 60000
   maxRefreshDelay: 600000
   expectedEntityId: https://dev-hub.local

--- a/configuration/hub/saml-soap-proxy.yml
+++ b/configuration/hub/saml-soap-proxy.yml
@@ -75,6 +75,9 @@ metadata:
   uri: ${METADATA_URL:-http://localhost:55000/metadata.xml}
   trustStorePath: data/pki/metadata.ts
   trustStorePassword: marshmallow
+  trustStore:
+    path: data/pki/metadata.ts
+    password: marshmallow
   minRefreshDelay: 60000
   maxRefreshDelay: 600000
   expectedEntityId: https://dev-hub.local


### PR DESCRIPTION
SAML Engine, SAML SOAP Proxy and SAML Proxy will use
TrustStoreBackedMetadataConfiguration instead of
TrustStorePathMetadataConfiguration. These changes require
trustStore.path and trustStore.password to be added to their config
files.

Co-authored-by: Rachel Smith
<rachel.smith@digital.cabinet-office.gov.uk>
Co-authored-by: Kornelis Sietsma
<kornelis.sietsma@digital.cabinet-office.gov.uk>