### PR TITLE
CTV-180 add translationDirectory to local config

### DIFF
--- a/configuration/hub/config.yml
+++ b/configuration/hub/config.yml
@@ -20,6 +20,8 @@ serviceInfo:
 
 rootDataDirectory: data/stub-fed-config
 
+translationsDirectory: ../display-locales/transactions
+
 clientTrustStoreConfiguration:
   path: data/pki/hub.ts
   password: marshmallow


### PR DESCRIPTION
this is being introduced to try and keep verify-local-startup up to date with the local config needed in ida-hub-acceptance-tests