### PR TITLE
BAU: Modify generate scripts to generate pki/config for acceptance tests

### DIFF
--- a/apps.yml
+++ b/apps.yml
@@ -9,3 +9,5 @@ stub-idp: ../verify-stub-idp/docker-run.sh
 test-rp: ../verify-test-rp/docker-run.sh
 msa: ../verify-matching-service-adapter/docker-run.sh
 frontend: ../verify-frontend/docker-run.sh
+
+aggregator: docker build bin -f bin/aggregator.Dockerfile -t local-aggregator:latest && echo "local-aggregator:latest"

--- a/bin/Gemfile
+++ b/bin/Gemfile
@@ -1,0 +1,5 @@
+source "http://rubygems.org"
+
+group :development do
+  gem 'webrick'
+end

--- a/bin/aggregator.Dockerfile
+++ b/bin/aggregator.Dockerfile
@@ -1,0 +1,10 @@
+FROM ruby:2.4.2
+
+RUN gem install bundle
+
+COPY Gemfile Gemfile
+RUN bundle install
+
+COPY aggregator.rb aggregator.rb
+
+CMD bundle exec aggregator.rb

--- a/bin/aggregator.rb
+++ b/bin/aggregator.rb
@@ -1,0 +1,18 @@
+#!/usr/bin/env ruby
+
+require 'webrick'
+require 'net/http'
+
+class Aggregator < WEBrick::HTTPServlet::AbstractServlet
+  def do_GET(request, response)
+    # Decode hex entity ID
+    hex_entity_id = request.path[1..-1].split('/').last
+    entity_id = [hex_entity_id].pack('H*')
+    uri = URI(entity_id)
+    response.body = Net::HTTP.get(uri)
+  end
+end
+
+aggregated_metadata_server = WEBrick::HTTPServer.new(:Port => 80)
+aggregated_metadata_server.mount("/", Aggregator)
+aggregated_metadata_server.start

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 services:
   config:
@@ -47,7 +47,7 @@ services:
       - ./data:/app/data:ro
 
   stub-event-sink:
-    image: ${SAML_SOAP_PROXY_IMAGE}
+    image: ${STUB_EVENT_SINK_IMAGE}
     environment:
       APP_NAME: stub-event-sink
     volumes:
@@ -68,6 +68,9 @@ services:
     image: nginx
     volumes:
       - ./data/metadata:/usr/share/nginx/html:ro
+
+  metadata-aggregator:
+    image: ${AGGREGATOR_IMAGE}
 
   stub-idp:
     image: ${STUB_IDP_IMAGE}

--- a/generate/fed-config.rb
+++ b/generate/fed-config.rb
@@ -22,17 +22,21 @@ idps = {
   'stub-idp-one' => { 'enabled' => false },
   'stub-idp-two' => { 'useExactComparisonType' => false },
   'stub-idp-three' => {},
-  'stub-idp-four' => {}
+  'stub-idp-four' => {},
+  'stub-idp-demo' => {}
 }
 
 rps = {
-  'dev-rp' => {
+  'test-rp' => {
     'simpleId' => 'test-rp',
     'matchingProcess' => { 'cycle3AttributeName' => 'NationalInsuranceNumber' }
   },
-  'dev-rp-no-eidas' => {
+  'test-rp-non-eidas' => {
     'simpleId' => 'test-rp',
     'eidasEnabled' => false
+  },
+  'test-rp-noc3' => {
+    'simpleId' => 'test-rp'
   }
 }
 
@@ -54,7 +58,7 @@ translations = {
 }
 
 countries = {
-  'reference' => { 'simpleId' => 'ZZ' },
+  'stub' => { 'simpleId' => 'YY', 'entityId' => "#{ENV.fetch('COUNTRY_METADATA_URI')}" },
   'netherlands' => { 'simpleId' => 'NL' },
   'spain' => { 'simpleId' => 'ES', 'overriddenSsoUrl' => 'http://spain.country/sso-override' },
   'sweden' => { 'simpleId' => 'SE', 'enabled' => false },
@@ -82,18 +86,16 @@ Dir::chdir(output_dir) do
   end
 
   Dir::chdir('matching-services') do
-    rps.each do |rp, _|
-      File.open("#{rp}-ms.yml", 'w') do |f|
-        msa_url = "#{ENV.fetch('MSA_URI')}"
-        f.write(YAML.dump(
-          'entityId' => "http://#{rp}-ms.local/SAML2/MD",
-          'healthCheckEnabled' => true,
-          'uri' => "#{msa_url}/matching-service/POST",
-          'userAccountCreationUri' => "#{msa_url}/unknown-user-attribute-query",
-          'signatureVerificationCertificates' => [ { 'x509' => inline_cert(msa_signing_cert) } ],
-          'encryptionCertificate' => { 'x509' => inline_cert(msa_encryption_cert) }
-        ))
-      end
+    File.open("test-rp-ms.yml", 'w') do |f|
+      msa_url = "#{ENV.fetch('MSA_URL')}"
+      f.write(YAML.dump(
+        'entityId' => "http://test-rp-ms.local/SAML2/MD",
+        'healthCheckEnabled' => true,
+        'uri' => "#{msa_url}/matching-service/POST",
+        'userAccountCreationUri' => "#{msa_url}/unknown-user-attribute-query",
+        'signatureVerificationCertificates' => [ { 'x509' => inline_cert(msa_signing_cert) } ],
+        'encryptionCertificate' => { 'x509' => inline_cert(msa_encryption_cert) }
+      ))
     end
   end
 
@@ -107,7 +109,7 @@ Dir::chdir(output_dir) do
             { 'uri' => "#{ENV.fetch('TEST_RP_URI')}/test-rp/login", 'index' => 0, 'isDefault' => true }
           ],
           'levelsOfAssurance' => [ 'LEVEL_2' ],
-          'matchingServiceEntityId' => "http://#{rp}-ms.local/SAML2/MD",
+          'matchingServiceEntityId' => "http://test-rp-ms.local/SAML2/MD",
           'displayName' => 'Register for an identity profile',
           'otherWaysDescription' => 'access Dev RP',
           'serviceHomepage' => "http://#{rp}.local/home",

--- a/generate/generate-metadata.sh
+++ b/generate/generate-metadata.sh
@@ -7,8 +7,8 @@ output="metadata/output"
 cadir="$PWD/ca-certificates"
 certdir="$PWD/pki"
 
+mkdir -p "$sources/dev-connector"
 mkdir -p "$sources/dev/idps"
-mkdir -p "$sources/compliance-tool/idps"
 rm -f "$output/*"
 
 # generate
@@ -21,13 +21,6 @@ $script_dir/metadata-sources.rb \
   "$certdir"/stub_idp_signing_primary.crt \
   "$sources/dev" || exit 1
 
-env FRONTEND_URL="http://localhost:${COMPLIANCE_TOOL_PORT}" \
-  $script_dir/metadata-sources.rb \
-  "$certdir"/hub_signing_primary.crt \
-  "$certdir"/hub_encryption_primary.crt \
-  "$certdir"/stub_idp_signing_primary.crt \
-  "$sources/compliance-tool" || exit 1
-
 echo "$(tput setaf 3)Generating metadata XML$(tput sgr0)"
 bundle exec generate_metadata -c "$sources" -e dev -w -o "$output" --valid-until=36500 \
   --hubCA "$cadir"/dev-root-ca.pem.test \
@@ -35,34 +28,35 @@ bundle exec generate_metadata -c "$sources" -e dev -w -o "$output" --valid-until
   --idpCA "$cadir"/dev-root-ca.pem.test \
   --idpCA "$cadir"/dev-idp-ca.pem.test
 
-for src in dev compliance-tool; do
-  bundle exec generate_metadata -c "$sources" -e $src -w -o "$output" --valid-until=36500 \
-    --hubCA "$cadir"/dev-root-ca.pem.test \
-    --hubCA "$cadir"/dev-hub-ca.pem.test \
-    --idpCA "$cadir"/dev-root-ca.pem.test \
-    --idpCA "$cadir"/dev-idp-ca.pem.test
-  
-  if test ! -f "$output"/$src/metadata.xml; then
-    echo "$(tput setaf 1)Failed to generate metadata$(tput sgr0)"
-    exit 1
-  fi
-  
-  # sign
-  if test -z `which xmlsectool`; then
-    echo "$(tput setaf 3)Installing xmlsectool$(tput sgr0)"
-    brew install xmlsectool
-  fi
-  
+echo "$(tput setaf 3)Generating connector metadata XML$(tput sgr0)"
+bundle exec generate_metadata -c "$sources" -e dev-connector -r -w -o "$output" --valid-until=36500 \
+  --hubCA "$cadir"/dev-root-ca.pem.test \
+  --hubCA "$cadir"/dev-hub-ca.pem.test \
+  --idpCA "$cadir"/dev-root-ca.pem.test \
+  --idpCA "$cadir"/dev-idp-ca.pem.test
+
+if test ! -f "$output"/dev/metadata.xml; then
+  echo "$(tput setaf 1)Failed to generate metadata$(tput sgr0)"
+  exit 1
+fi
+
+# sign
+if test -z `which xmlsectool`; then
+  echo "$(tput setaf 3)Installing xmlsectool$(tput sgr0)"
+  brew install xmlsectool
+fi
+
+for env in dev dev-connector; do
   echo "$(tput setaf 3)Signing metadata$(tput sgr0)"
   xmlsectool \
     --sign \
-    --inFile "$output"/$src/metadata.xml \
-    --outFile "$output"/$src/metadata.signed.xml \
+    --inFile "$output"/$env/metadata.xml \
+    --outFile "$output"/$env/metadata.signed.xml \
     --certificate "$certdir"/metadata_signing_a.crt \
     --key "$certdir"/metadata_signing_a.pk8 \
     --digest SHA-256
 
-  cp metadata/output/$src/metadata.signed.xml metadata/$src.xml
+  cp metadata/output/$env/metadata.signed.xml metadata/$env.xml
 done
 
 echo "$(tput setaf 3)Generating compatible federation config$(tput sgr0)"

--- a/generate/generate-trust-anchor.sh
+++ b/generate/generate-trust-anchor.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+cd $(dirname "${BASH_SOURCE[0]}")
+
+TRUST_ANCHOR_IMAGE=govukverify/trust-anchor
+pushd ../data > /dev/null
+  docker run -v $(pwd):/tmp:ro $TRUST_ANCHOR_IMAGE import "$COUNTRY_METADATA_URI" \
+    /tmp/pki/stub_idp_signing_primary.crt \
+    /tmp/ca-certificates/dev-idp-ca.pem.test \
+    /tmp/ca-certificates/dev-root-ca.pem.test > trust-anchor.jwk
+
+  docker run -v $(pwd):/tmp:ro $TRUST_ANCHOR_IMAGE sign-with-file \
+    --key /tmp/pki/metadata_signing_a.pk8 \
+    --cert /tmp/pki/metadata_signing_a.crt \
+    /tmp/trust-anchor.jwk > metadata/trust-anchor
+popd > /dev/null
+

--- a/generate/hub-dev-pki.sh
+++ b/generate/hub-dev-pki.sh
@@ -13,6 +13,18 @@ cat <<EOF
 EOF
 tput sgr0
 
+unset_message="should be set to the runtime location (for metadata/fed config setting)"
+quit() {
+  echo $1
+  exit 1
+}
+test -z $HUB_CONNECTOR_ENTITY_ID && quit "HUB_CONNECTOR_ENTITY_ID $unset_message"
+test -z $FRONTEND_URL && quit "FRONTEND_URL $unset_message"
+test -z $STUB_IDP_URL && quit "STUB_IDP_URL $unset_message"
+test -z $TEST_RP_URL && quit "TEST_RP_URL $unset_message"
+test -z $MSA_URL && quit "MSA_URL $unset_message"
+test -z $COUNTRY_METADATA_URI && quit "COUNTRY_METADATA_URI $unset_message"
+
 script_dir="$(cd $(dirname "${BASH_SOURCE[0]}") && pwd)"
 source "$script_dir"/../config/env.sh
 data_dir="$script_dir/../data"
@@ -23,7 +35,7 @@ pushd "$data_dir" >/dev/null
   rm -rf {pki,metadata,stub-fed-config}
   mkdir -p {pki,metadata,stub-fed-config}
 
-  mkdir -p metadata/output/{dev,compliance-tool}
+  mkdir -p metadata/output/{dev,dev-connector}
   mkdir -p stub-fed-config
 
   env \
@@ -33,4 +45,5 @@ pushd "$data_dir" >/dev/null
 
   $script_dir/generate-truststores.sh
   $script_dir/generate-metadata.sh
+  $script_dir/generate-trust-anchor.sh
 popd >/dev/null

--- a/generate/metadata-sources.rb
+++ b/generate/metadata-sources.rb
@@ -24,13 +24,14 @@ idps = {
   'Stub IDP One' => 'stub-idp-one',
   'Stub IDP Two' => 'stub-idp-two',
   'Stub IDP Three' => 'stub-idp-three',
-  'Stub IDP Four' => 'stub-idp-four'
+  'Stub IDP Four' => 'stub-idp-four',
+  'Stub IDP Demo' => 'stub-idp-demo'
 }
 
 hub_yaml = {
   'id' => 'VERIFY-HUB',
-  'entity_id' => 'https://dev-hub.local',
-  'assertion_consumer_service_uri' => "#{ENV.fetch('FRONTEND_URI')}/SAML2/SSO/Response/POST",
+  'entity_id' => "#{ENV.fetch('HUB_CONNECTOR_ENTITY_ID')}",
+  'assertion_consumer_service_uri' => "#{ENV.fetch('FRONTEND_URL')}/SAML2/SSO/Response/POST",
   'organization' => { 'name' => 'Hub', 'url' => 'http://localhost', 'display_name' => 'Hub' },
   'signing_certificates' => [
     { 'name' => 'signing_primary', 'x509' => block_cert(hub_signing_cert) }
@@ -57,4 +58,9 @@ Dir::chdir(output_dir) do
     )
     File.open(File.join('idps', "#{id}.yml"), 'w') { |f| f.write(YAML.dump(yaml)) }
   end
+end
+
+Dir::chdir(output_dir + "-connector") do
+  hub_yaml.update('assertion_consumer_service_uri' => "#{ENV.fetch('FRONTEND_URL')}/SAML2/SSO/EidasResponse/POST")
+  File.open('hub.yml', 'w') { |f| f.write(YAML.dump(hub_yaml)) }
 end


### PR DESCRIPTION
- Modify scripts to generate eIDAS compatible config
  - Add connector metadata
  - Add trust anchor generation
  - Add rps for eIDAS
  - Add stub country config
- Added stub-idp-demo for supporting acceptance tests
- Removed unnecessary config for multiple MSAs