### PR TITLE
Bau - Add eidasEnabled variable value

### DIFF
--- a/config/ports.env
+++ b/config/ports.env
@@ -22,3 +22,5 @@ TEST_RP_URI=http://localhost:50130
 HUB_CONNECTOR_ENTITY_ID="http://localhost:55000/local-connector/metadata.xml"
 TRUST_ANCHOR_URI="http://localhost:55000/local/trust-anchor.jws"
 METADATA_SOURCE_URI="http://localhost:55001"
+
+EIDAS_ENABLED=true


### PR DESCRIPTION
-This will allow eidas journey to work when starting hub
through ida-hub-acceptance-test
-Please also refer to ida-hub-acceptance-test PR 