### PR TITLE
TRELLO-auJ7kBAx: Remove SQS queue from Event Emitter configuration 

### DIFF
--- a/configuration/hub/policy.yml
+++ b/configuration/hub/policy.yml
@@ -68,3 +68,4 @@ eventEmitterConfiguration:
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}

--- a/configuration/hub/policy.yml
+++ b/configuration/hub/policy.yml
@@ -67,6 +67,4 @@ eventEmitterConfiguration:
   accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
-  queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}

--- a/configuration/hub/policy.yml
+++ b/configuration/hub/policy.yml
@@ -16,9 +16,9 @@ logging:
 
 
 infinispan:
-  bindAddress: 
-  initialHosts: 
-  clusterName: 
+  bindAddress:
+  initialHosts:
+  clusterName:
   type: standalone
   expiration: 8h
   persistenceToFileEnabled: false
@@ -68,4 +68,4 @@ eventEmitterConfiguration:
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
-  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL:-http://not.used}

--- a/configuration/hub/saml-proxy.yml
+++ b/configuration/hub/saml-proxy.yml
@@ -83,4 +83,4 @@ eventEmitterConfiguration:
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
-  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL:-http://not.used}

--- a/configuration/hub/saml-proxy.yml
+++ b/configuration/hub/saml-proxy.yml
@@ -83,3 +83,4 @@ eventEmitterConfiguration:
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}

--- a/configuration/hub/saml-proxy.yml
+++ b/configuration/hub/saml-proxy.yml
@@ -82,6 +82,4 @@ eventEmitterConfiguration:
   accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
-  queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}

--- a/configuration/hub/saml-soap-proxy.yml
+++ b/configuration/hub/saml-soap-proxy.yml
@@ -99,3 +99,4 @@ eventEmitterConfiguration:
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}

--- a/configuration/hub/saml-soap-proxy.yml
+++ b/configuration/hub/saml-soap-proxy.yml
@@ -98,6 +98,4 @@ eventEmitterConfiguration:
   accessKeyId: ${EVENT_EMITTER_ACCESS_KEY_ID}
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
-  queueAccountId: ${EVENT_EMITTER_ACCOUNT_ID}
-  sourceQueueName: ${EVENT_EMITTER_SOURCE_QUEUE_NAME}
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}

--- a/configuration/hub/saml-soap-proxy.yml
+++ b/configuration/hub/saml-soap-proxy.yml
@@ -99,4 +99,4 @@ eventEmitterConfiguration:
   secretAccessKey: ${EVENT_EMITTER_SECRET_ACCESS_KEY}
   region: eu-west-2
   encryptionKey: ${EVENT_EMITTER_ENCRYPTION_KEY}
-  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL}
+  apiGatewayUrl: ${EVENT_EMITTER_API_GATEWAY_URL:-http://not.used}


### PR DESCRIPTION
Event Emitter now sends events to the API Gateway and not directly to the SQS queue.

Instead of sending directly to the SQS queue each event will now go through an API gateway

https://trello.com/c/auJ7kBAx/120-upgrade-event-emitter-library-in-hub

Co-authored-by: dbes_gds daniel.besbrode@digital.cabinet-office.gov.uk