### PR TITLE
BAU: Remove hub certs from SAML Engine

### DIFF
--- a/configuration/hub/saml-engine.yml
+++ b/configuration/hub/saml-engine.yml
@@ -48,18 +48,7 @@ readKeysFromFileDescriptors: false
 privateSigningKeyConfiguration:
   keyFile: data/pki/hub_signing_primary.pk8
 
-publicSigningCert:
-   certFile: data/pki/hub_signing_primary.crt
-   name: someId
-
 primaryPrivateEncryptionKeyConfiguration:
-  keyFile: data/pki/hub_encryption_primary.pk8
-
-primaryPublicEncryptionCert:
-   certFile: data/pki/hub_encryption_primary.crt
-   name: someId
-
-secondaryPrivateEncryptionKeyConfiguration:
   keyFile: data/pki/hub_encryption_primary.pk8
 
 secondaryPublicEncryptionCert:


### PR DESCRIPTION
Since https://github.com/alphagov/verify-hub/pull/122 SAML Engine doesn't need these certs. Remove them.