### PR TITLE
make start_service_checker work under `set -e`

### DIFF
--- a/lib/services.sh
+++ b/lib/services.sh
@@ -25,9 +25,13 @@ start_service_checker() {
   local MAX_RETRIES=10
 
   for i in $(seq 1 $MAX_RETRIES); do
-    curl --silent --output /dev/null $endpoint
-    s=$?
-    test "$s" -eq 0 && break || sleep 5
+    if curl --silent --output /dev/null $endpoint ; then
+      s=$?
+      break
+    else
+      s=$?
+      sleep 5
+    fi
   done
 
   if test "$s" -eq 0; then


### PR DESCRIPTION
ida-hub-acceptance-tests#92 introduced the use of `set -e` for
aborting when commands unexpectedly fail.

However, start_service_checker had a curl command which was expected
to fail, at least until the service comes up.  Therefore, `set -e`
caused start_service_checker to bomb out if curl ever failed.

This commit changes the function to run curl inside an `if` block,
which causes bash not to abort under `set -e` if curl fails.

I happen to think that the if block is more readable than the
`&& break || sleep 5` thing that it replaced, too. :)