### PR TITLE
FIREBREAK: Rename test-rp

### DIFF
--- a/configuration/stub-frontend-fed-config/locales/rps/test-rp-no-ab-test.yml
+++ b/configuration/stub-frontend-fed-config/locales/rps/test-rp-no-ab-test.yml
@@ -1,16 +1,16 @@
 en:
   rps:
     test-rp-no-ab-test:
-      name: register for an identity profile
+      name: test GOV.UK Verify user journeys
       rp_name: Test RP
       analytics_description: analytics description for test-rp-no-ab-test
       other_ways_text: |
-        <p>If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile <a href="http://www.example.com">here</a>.</p>
+        <p>If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys <a href="http://www.example.com">here</a>.</p>
         <p>Tell us your:</p>
         <ul>
          <li>name</li>
          <li>age</li>
         </ul>
         <p>Include any other relevant details if you have them.</p>
-      other_ways_description: register for an identity profile
+      other_ways_description: test GOV.UK Verify user journeys
       tailored_text: <p>This is tailored text for test-rp</p>

--- a/configuration/stub-frontend-fed-config/locales/rps/test-rp-no-demo.yml
+++ b/configuration/stub-frontend-fed-config/locales/rps/test-rp-no-demo.yml
@@ -2,7 +2,7 @@
 cy:
   rps:
     test-rp-no-demo:
-      name: register for an identity profile
+      name: test GOV.UK Verify user journeys
       rp_name: Test RP No Demo
       analytics_description: TEST RP NO DEMO
       other_ways_description: access TestRP No Demo
@@ -18,7 +18,7 @@ cy:
 en:
   rps:
     test-rp-no-demo:
-      name: register for an identity profile
+      name: test GOV.UK Verify user journeys
       rp_name: Test RP No Demo
       analytics_description: TEST RP NO DEMO
       other_ways_description: access TestRP No Demo

--- a/configuration/stub-frontend-fed-config/locales/rps/test-rp-noc3.yml
+++ b/configuration/stub-frontend-fed-config/locales/rps/test-rp-noc3.yml
@@ -1,9 +1,9 @@
 en:
   rps:
     test-rp-noc3:
-      name: Register for an identity profile (forceauthn & no cycle3)
+      name: Test GOV.UK Verify user journeys (forceauthn & no cycle3)
       rp_name: Test RP
       analytics_description: analytics description for test-rp-noc3
-      other_ways_text: If you can’t verify your identity using GOV.UK Verify, there are other ways to <a href='http://www.example.com'>register for an identity profile (forceauthn & no cycle3)</a>
-      other_ways_description: other ways to register for an identity profile (forceauthn & no cycle3)
+      other_ways_text: If you can’t verify your identity using GOV.UK Verify, there are other ways to <a href='http://www.example.com'>test GOV.UK Verify user journeys (forceauthn & no cycle3)</a>
+      other_ways_description: other ways to test GOV.UK Verify user journeys (forceauthn & no cycle3)
       tailored_text: <p>This is tailored text for test-rp-noc3</p>

--- a/configuration/stub-frontend-fed-config/locales/rps/test-rp-non-eidas.yml
+++ b/configuration/stub-frontend-fed-config/locales/rps/test-rp-non-eidas.yml
@@ -1,17 +1,17 @@
 en:
   rps:
     test-rp-non-eidas:
-      name: register for an identity profile
+      name: test GOV.UK Verify user journeys
       rp_name: Test RP
       analytics_description: analytics description for test-rp-non-eidas
       other_ways_text: |
-        <p>If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile <a href="http://www.example.com">here</a>.</p>
+        <p>If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys <a href="http://www.example.com">here</a>.</p>
         <p>Tell us your:</p>
         <ul>
          <li>name</li>
          <li>age</li>
         </ul>
         <p>Include any other relevant details if you have them.</p>
-      other_ways_description: register for an identity profile
+      other_ways_description: test GOV.UK Verify user journeys
       tailored_text: <p>This is tailored text for test-rp</p>
       taxon_name: Benefits

--- a/configuration/stub-frontend-fed-config/locales/rps/test-rp-repudiation.yml
+++ b/configuration/stub-frontend-fed-config/locales/rps/test-rp-repudiation.yml
@@ -1,10 +1,10 @@
 en:
   rps:
     test-rp-repudiation:
-      name: Register for an identity profile (repudiation step)
+      name: Test GOV.UK Verify user journeys (repudiation step)
       rp_name: Test RP
       analytics_description: analytics description for test-rp-repudiation
-      other_ways_text: If you can’t verify your identity using GOV.UK Verify, there are other ways to <a href='http://www.example.com'>register for an identity profile (repudiation step)</a>
-      other_ways_description: other ways to register for an identity profile (repudiation step)
+      other_ways_text: If you can’t verify your identity using GOV.UK Verify, there are other ways to <a href='http://www.example.com'>test GOV.UK Verify user journeys (repudiation step)</a>
+      other_ways_description: other ways to test GOV.UK Verify user journeys (repudiation step)
       tailored_text: <p>This is tailored text for test-rp-repudiation</p>
       taxon_name: Benefits

--- a/configuration/stub-frontend-fed-config/locales/rps/test-rp-with-continue-on-fail.yml
+++ b/configuration/stub-frontend-fed-config/locales/rps/test-rp-with-continue-on-fail.yml
@@ -1,7 +1,7 @@
 en:
   rps:
     test-rp-with-continue-on-fail:
-      name: register for an identity profile
+      name: test GOV.UK Verify user journeys
       rp_name: Test RP
       analytics_description: analytics description for test-rp
       other_ways_text: <p>You can still continue to complete your transaction.</p>

--- a/configuration/stub-frontend-fed-config/locales/rps/test-rp.yml
+++ b/configuration/stub-frontend-fed-config/locales/rps/test-rp.yml
@@ -1,17 +1,17 @@
 en:
   rps:
     test-rp:
-      name: register for an identity profile
+      name: test GOV.UK Verify user journeys
       rp_name: Test RP
       analytics_description: analytics description for test-rp
       other_ways_text: |
-        <p>If you can’t verify your identity using GOV.UK Verify, you can register for an identity profile <a href="http://www.example.com">here</a>.</p>
+        <p>If you can’t verify your identity using GOV.UK Verify, you can test GOV.UK Verify user journeys <a href="http://www.example.com">here</a>.</p>
         <p>Tell us your:</p>
         <ul>
          <li>name</li>
          <li>age</li>
         </ul>
         <p>Include any other relevant details if you have them.</p>
-      other_ways_description: register for an identity profile
+      other_ways_description: test GOV.UK Verify user journeys
       tailored_text: <p>This is tailored text for test-rp</p>
       taxon_name: Benefits

--- a/generate/fed-config.rb
+++ b/generate/fed-config.rb
@@ -41,7 +41,7 @@ translations = {
     'translations' => [
       {
         'locale' => 'en',
-        'name' => 'register for an identity profile',
+        'name' => 'test GOV.UK Verify user journeys',
         'rpName' => 'Test RP',
         'analyticsDescription' => 'TEST RP',
         'otherWaysDescription' => 'access TestRP',
@@ -108,7 +108,7 @@ Dir::chdir(output_dir) do
           ],
           'levelsOfAssurance' => [ 'LEVEL_2' ],
           'matchingServiceEntityId' => "http://#{rp}-ms.local/SAML2/MD",
-          'displayName' => 'Register for an identity profile',
+          'displayName' => 'Test GOV.UK Verify user journeys',
           'otherWaysDescription' => 'access Dev RP',
           'serviceHomepage' => "http://#{rp}.local/home",
           'rpName' => 'Dev RP',


### PR DESCRIPTION
Renaming test-rp name "register for an identity" profile to "test GOV.UK Verify user journeys" to make the content more readable.