### PR TITLE
ly1m24h4: remove unused file

### DIFF
--- a/configuration/stub-frontend-fed-config/identity_providers.yml
+++ b/configuration/stub-frontend-fed-config/identity_providers.yml
@@ -1,4 +1,0 @@
-show_unavailable:
-    - stub-idp-unavailable
-
-loa1_order: ["stub-idp-loa1", "stub-idp-one"]


### PR DESCRIPTION
Remove a file no longer used - the config has been moved to verify-hub-federation-config instead

See https://trello.com/c/ly1m24h4/42-communicate-to-users-when-idp-is-having-technical-difficulty