### PR TITLE
BAU: Fix Verify Stub IDP's DB connection failure

### DIFF
--- a/generate-env.rb
+++ b/generate-env.rb
@@ -72,7 +72,7 @@ IDP = <<~IDP
     EUROPEAN_IDENTITY_ENABLED=true
     STUB_COUNTRY_SIGNING_PRIVATE_KEY="$STUB_IDP_SIGNING_PRIVATE_KEY"
     STUB_COUNTRY_SIGNING_CERT="$STUB_IDP_SIGNING_CERT"
-    DB_URI="jdbc:postgresql://localhost:5432/postgres?user=postgres"
+    DB_URI="jdbc:postgresql://localhost:5432/postgres?user=postgres&password=docker"
   IDP
 
 applications = {


### PR DESCRIPTION
Verify Stub IDP failed to connect to its PostgreSQL database due to a missing password. This change adds a password to fix the database connection error. This change is needed because Verify Stub IDP's startup script specifies the password for its database (source: https://github.com/alphagov/verify-stub-idp/blob/a401e5185a07d280ec368225f37a653c59fe1b0e/startup.sh#L22).

Author: @adityapahuja