### PR TITLE
Introduce retries to the build script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # This Dockerfile is for generating the Metadata
 # and environment used for running the HUB.
-FROM golang:1.15.4-alpine3.12 as golang
+FROM ghcr.io/alphagov/verify/golang:1.15.5-alpine3.12 as golang
 
 RUN apk --no-cache upgrade && \
     apk add --no-cache build-base git &&\
     go get -u github.com/cloudflare/cfssl/cmd/...
 
-FROM ruby:2.7.2-alpine3.12
+FROM ghcr.io/alphagov/verify/ruby:2.7.2-alpine3.12
 
 RUN apk --no-cache upgrade && \
     apk add --no-cache build-base ncurses bash git openssl openjdk8 curl

--- a/build-local.rb
+++ b/build-local.rb
@@ -52,7 +52,7 @@ class ImageBuilder
     @output = "Starting build of #{repo_name}...\n"
   end
 
-  def build_image()
+  def build_image
     image_name = "#{@repo_name}:local"
     build_args = @config.fetch('build-args', []).map { |ba| "--build-arg #{ba.keys[0]}=#{ba.values[0]}" }.join " "
     cmd = "docker build #{build_args}\
@@ -73,9 +73,9 @@ class ImageBuilder
       @image_var = "#{@config['image_env_var']}=#{image_name}\n"
       @success = true
     elsif @retries > 0
-        @output = @output + output + "\nBuild failed... Retrying...\n"
-        @retries = @retries - 1
-        build_image()
+      @output = @output + output + "\nBuild failed... Retrying...\n"
+      @retries = @retries - 1
+      build_image
     else
       @output = @output + output + "\nBuild failed... Unable to retry.\n" 
       File.write("#{@script_dir}/logs/#{@repo_name}_build.log", "log from command=#{cmd}\n#{output}", mode: "w")
@@ -84,7 +84,7 @@ class ImageBuilder
     end
   end
 
-  def get_repo()
+  def get_repo
     cmd = "git clone https://github.com/alphagov/#{@config['context']}.git ../#{@config['context']} 2>&1"
     output = `#{cmd}`
     unless $?.success?
@@ -96,13 +96,13 @@ class ImageBuilder
     true
   end
 
-  def get_release()
+  def get_release
     cmd = "git -C ../#{@config['context']} rev-parse --short HEAD"
     output = `#{cmd}`
     @release = output.strip
   end
 
-  def run()
+  def run
     have_repo = true
     unless File.exists?("../#{@config['context']}")
       have_repo = get_repo
@@ -204,7 +204,7 @@ def main()
     puts HELP if args[:help]
     exit
   end
-  if ! File.file?(args[:yaml])
+  unless File.file?(args[:yaml])
     puts "Yaml file does not exist.  Exiting..."
     puts USAGE
     exit 1
@@ -218,11 +218,11 @@ def main()
   # Setup thread count
   thread_count = args[:threads].to_i
   # Setup retries
-  retries = args[:retris].to_i
+  retries = args[:retries].to_i
 
   write_success_log = args[:write_success_log]
 
-  if OS.mac? && thread_count == 0
+  if OS.mac? && thread_count.zero?
     thread_count = 2
     puts "For your safety we are using #{thread_count} threads to do the build."
     puts "You can override this using the -t option."

--- a/build-local.rb
+++ b/build-local.rb
@@ -65,7 +65,7 @@ class ImageBuilder
     if $?.success?
       if @write_success_log
         @spinner.success(" - see #{@script_dir}/logs/#{@repo_name}_build.log")
-        @putput = @output + output + "\nBuild failed... Unable to retry.\n" 
+        @output = @output + output + "\nBuild failed... Unable to retry.\n" 
         File.write("#{@script_dir}/logs/#{@repo_name}_build.log", "log from command=#{cmd}\n#{output}", mode: "w")
       else
         @spinner.success
@@ -77,7 +77,7 @@ class ImageBuilder
         @retries = @retries - 1
         build_image()
     else
-      @putput = @output + output + "\nBuild failed... Unable to retry.\n" 
+      @output = @output + output + "\nBuild failed... Unable to retry.\n" 
       File.write("#{@script_dir}/logs/#{@repo_name}_build.log", "log from command=#{cmd}\n#{output}", mode: "w")
       @spinner.error(" - see #{@script_dir}/logs/#{@repo_name}_build.log")
       @success = false

--- a/build-local.rb
+++ b/build-local.rb
@@ -19,7 +19,7 @@ ENDBANNER
 
 USAGE = <<ENDUSAGE
 Usage:
-    build-local -y yaml-file [-t count] [-h]
+    build-local -y yaml-file [-t count] [-r retires] [-h]
 ENDUSAGE
 
 HELP = <<ENDHELP
@@ -27,6 +27,10 @@ HELP = <<ENDHELP
     -t, --threads           Specifies the number of threads to use to do the
                             the build.  If no number given will generate as many
                             threads as repos.  Suggested 4 threads
+    -r, --retry-build       Sometimes the build can fail due to a resourcing issue
+                            by default we'll always retry once.  If you want to
+                            retry more times set a number here or set it to 0 to
+                            not retry.
     -h, --help              Show's this help message
 ENDHELP
 
@@ -34,7 +38,7 @@ ENDHELP
 class ImageBuilder
   attr_accessor :image_var, :messages
 
-  def initialize(repo_name, config, spinner, images, script_dir)
+  def initialize(repo_name:, config:, spinner:, images:, script_dir:, retires:, write_success_log: false)
     @repo_name = repo_name
     @config = config
     @spinner = spinner
@@ -42,6 +46,8 @@ class ImageBuilder
     @script_dir = script_dir
     @success = false
     @release = "verify-local-startup dev"
+    @retries = retires
+    @output = "Starting build of #{repo_name}...\n"
   end
 
   def build_image()
@@ -55,10 +61,17 @@ class ImageBuilder
         2>&1"
     output = `#{cmd}`
     if $?.success?
-      @spinner.success
+      @spinner.success(" - see #{@script_dir}/logs/#{@repo_name}_build.log")
+      @putput = @output + output + "\nBuild failed... Unable to retry.\n" 
+      File.write("#{@script_dir}/logs/#{@repo_name}_build.log", "log from command=#{cmd}\n#{output}", mode: "w")
       @image_var = "#{@config['image_env_var']}=#{image_name}\n"
       @success = true
+    elsif @retries > 0
+        @output = @output + output + "\nBuild failed... Retrying...\n"
+        @retries = @retries - 1
+        build_image()
     else
+      @putput = @output + output + "\nBuild failed... Unable to retry.\n" 
       File.write("#{@script_dir}/logs/#{@repo_name}_build.log", "log from command=#{cmd}\n#{output}", mode: "w")
       @spinner.error(" - see #{@script_dir}/logs/#{@repo_name}_build.log")
       @success = false
@@ -99,7 +112,7 @@ class ImageBuilder
   end
 end
 
-def create_docker_images(thread_count, repos)
+def create_docker_images(thread_count, repos, retires)
   thread_success_marks = ["✅","🎉","🎆"]
   success_marks = "🎆 🎉 ✅ 🎉 🎆"
   error_mark = "❌ 😡 ❌ 😡 ❌"
@@ -114,7 +127,14 @@ def create_docker_images(thread_count, repos)
   repos.each do |repo_name, config|
     spinner = loading_spinners.register("[:spinner] #{repo_name}", format: :dots, success_mark: "#{thread_success_marks.sample}", error_mark: "😡")
     spinner.auto_spin
-    buildImage = ImageBuilder.new(repo_name, config, spinner, images, script_dir)
+    buildImage = ImageBuilder.new(
+        repo_name: repo_name,
+        config: config,
+        spinner: spinner,
+        images: images,
+        script_dir: script_dir,
+        retires: retires,
+        write_success_log: true)
     queue << buildImage
   end
 
@@ -154,7 +174,7 @@ def generate_env(images)
 end
 
 def main()
-  args = { :yaml=>'repos.yml', :thread_count=>0 }
+  args = { :yaml=>'repos.yml', :thread_count=>0, :retries=>1 }
   unflagged_args = []
   next_arg = unflagged_args.first
 
@@ -163,6 +183,7 @@ def main()
       when '-h', '--help'         then args[:help] = true
       when '-y', '--yaml-file'    then next_arg = :yaml
       when '-t', '--threads'      then next_arg = :threads
+      when '-r', '--retry-build'  then next_arg = :retires
       else
         if next_arg
           args[next_arg] = arg
@@ -189,6 +210,9 @@ def main()
   
   # Setup thread count
   thread_count = args[:threads].to_i
+  # Setup retries
+  retries = args[:retris].to_i
+
   if OS.mac? && thread_count == 0
     thread_count = 2
     puts "For your safety we are using #{thread_count} threads to do the build."
@@ -201,7 +225,7 @@ def main()
     puts "As you asked us we are using #{thread_count} threads to do the build."
   end
   puts ""
-  images = create_docker_images(thread_count, repos)
+  images = create_docker_images(thread_count, repos, retries)
   generate_env(images)
 end
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   redis:
-    image: redis:5.0.6
+    image: ghcr.io/alphagov/verify/redis:6.0.9
     volumes:
       - redis-data:/data
       - redis-config:/usr/local/etc/redis/
@@ -13,7 +13,7 @@ services:
       - hub-network
   
   stub-idp-db:
-    image: postgres
+    image: ghcr.io/alphagov/verify/postgres:6.0.9
     environment:
       POSTGRES_PASSWORD: docker
     volumes:
@@ -22,7 +22,7 @@ services:
       - hub-network
   
   metadata:
-    image: nginx
+    image: ghcr.io/alphagov/verify/nginx:latest
     ports:
       - "${METADATA_EXTERNAL_PORT}:80"
     volumes:

--- a/startup.sh
+++ b/startup.sh
@@ -7,12 +7,16 @@ Usage:
     -t, --threads           Specifies the number of threads to use to do the
                             the build.  If no number given will generate as many
                             threads as repos.  Suggested 4 threads
+    -r, --retry-build       Sometimes the build can fail due to resourcing issues
+                            by default we'll retry once.  If you want to retry
+                            more times set a number here or set it to 0 to not retry.
     -d, --dozzle            Run Dozzle for docker output viewing on port 50999
     -h, --help              Show's this help message
 EOF
 }
 
 THREADS=0
+RETRIES=1
 YAML_FILE=repos.yml
 DOZZLE=false
 DOZZLEPORT=50999
@@ -24,6 +28,9 @@ while [ "$1" != "" ]; do
                                 ;;
         -t | --threads)         shift
                                 THREADS=$1
+                                ;;
+        -r | --retry-build)     shift
+                                RETRIES=$1
                                 ;;
         -d | --dozzle)          DOZZLE=true
                                 ;;
@@ -84,7 +91,7 @@ fi
 
 if test ! "${1:-}" == "skip-build"; then
   bundle check || bundle install
-  bundle exec ./build-local.rb -y $YAML_FILE -t $THREADS
+  bundle exec ./build-local.rb -r $RETRIES -y $YAML_FILE -t $THREADS
 fi
 
 if [[ $DOZZLE == 'true' ]]; then

--- a/startup.sh
+++ b/startup.sh
@@ -10,6 +10,7 @@ Usage:
     -r, --retry-build       Sometimes the build can fail due to resourcing issues
                             by default we'll retry once.  If you want to retry
                             more times set a number here or set it to 0 to not retry.
+    -w, write-build-log     Writes the build log even for successful builds
     -d, --dozzle            Run Dozzle for docker output viewing on port 50999
     -h, --help              Show's this help message
 EOF
@@ -20,6 +21,7 @@ RETRIES=1
 YAML_FILE=repos.yml
 DOZZLE=false
 DOZZLEPORT=50999
+WRITE_BUILD_LOG=''
 
 while [ "$1" != "" ]; do
     case $1 in
@@ -31,6 +33,8 @@ while [ "$1" != "" ]; do
                                 ;;
         -r | --retry-build)     shift
                                 RETRIES=$1
+                                ;;
+        -w | --write-build-log) WRITE_BUILD_LOG='-w'
                                 ;;
         -d | --dozzle)          DOZZLE=true
                                 ;;
@@ -91,7 +95,7 @@ fi
 
 if test ! "${1:-}" == "skip-build"; then
   bundle check || bundle install
-  bundle exec ./build-local.rb -r $RETRIES -y $YAML_FILE -t $THREADS
+  bundle exec ./build-local.rb -r $RETRIES -y $YAML_FILE -t $THREADS $WRITE_BUILD_LOG
 fi
 
 if [[ $DOZZLE == 'true' ]]; then


### PR DESCRIPTION
Sometimes the integration tests will fail when building SAML-Soap-proxy and SAML-proxy.  This seems to be due to a bottle next in available system resources when this first tries to build.  Attempting to run startup again most times seems to result in a successful build.  So these changes attempt to retry the build if it fails so the user doesn't have to.

This also includes the Fixes for moving everything to GHCR