### PR TITLE
⚠ BAU Fix broken verify-local-startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,10 +18,10 @@ ADD Gemfile Gemfile
 ADD Gemfile.lock Gemfile.lock
 
 RUN bundle &&\
-    curl --silent -O https://shibboleth.net/downloads/tools/xmlsectool/latest/xmlsectool-2.0.0-bin.zip &&\
-    unzip xmlsectool-2.0.0-bin.zip
+    curl --silent -O https://shibboleth.net/downloads/tools/xmlsectool/latest/xmlsectool-3.0.0-bin.zip &&\
+    unzip xmlsectool-3.0.0-bin.zip
 
-ENV XMLSECTOOL="/xmlsectool-2.0.0/xmlsectool.sh"
+ENV XMLSECTOOL="/xmlsectool-3.0.0/xmlsectool.sh"
 ENV JAVA_HOME=/usr/lib/jvm/default-jvm/jre
 
 WORKDIR /verify-local-startup

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       - hub-network
   
   stub-idp-db:
-    image: ghcr.io/alphagov/verify/postgres:6.0.9
+    image: ghcr.io/alphagov/verify/postgres:12.5
     environment:
       POSTGRES_PASSWORD: docker
     volumes:


### PR DESCRIPTION
So looks like verify-local-startup has been broken for a few days.  This PR should fix any issue people are having.  Fixes include:

* Update XMLSecTool to version 3.0
* Fixed the docker-compose which was trying to pull down the wrong postgresql image

⚠ This PR is important to merge in quickly as peoples verify-local-startup will be broken until its applied.