### PR TITLE
BAU Fix deprecation warning from XMLSecTool

### DIFF
--- a/generate/generate-metadata.sh
+++ b/generate/generate-metadata.sh
@@ -63,7 +63,7 @@ for src in dev compliance-tool; do
     --outFile "$output"/$src/metadata.signed.xml \
     --referenceIdAttributeName ID \
     --certificate "$certdir"/metadata_signing_a.crt \
-    --key "$certdir"/metadata_signing_a.pk8 \
+    --keyFile "$certdir"/metadata_signing_a.pk8 \
     --digest SHA-256
 
   cp metadata/output/$src/metadata.signed.xml metadata/$src.xml


### PR DESCRIPTION
XMLSecTool was recently updated to version 3.0.0 and we've updated our use of the tool to version 3.0.0.  Version 3.0.0 of the tool deprecated the use of `--key` infavour of `--keyFile`.  This PR fixes our use of the tool to prevent the warning.