### PR TITLE
BUGFIX Fixes a pair of bugs which have been found in the component script

### DIFF
--- a/lib/components.rb
+++ b/lib/components.rb
@@ -54,7 +54,8 @@ def list_components(repos)
   status_heading = "Status" + "".ljust(15)
   out = "#{name_heading} #{status_heading} Created\n".bold
   repos.each do |repo_name, config|
-    process = running_info[repo_name] || {"state" => "missing"}
+    process = running_info[repo_name] 
+    process = container_info[repo_name] || {"state" => "missing"} if process.nil?
     running = case process["state"]
     when "running"  then "[ " + " Running ".green + " ]".ljust(10)
     when "missing"  then "[ " + "Not Built".red + " ]".ljust(10)


### PR DESCRIPTION
This PR fixes a pair of bugs in the component script.  The first is where a component which has never been run is incorrectly reported as missing when in fact its just not been run yet.  The second bug affects the rebuild process which was showing starting component when the logic says don't run if the component wasn't running to begin with.  Also it now shows a hint in the rebuild process that to start the rebuilt but stopped component run the script with the -s <component> option.