### PR TITLE
[HUB-841] Use docker hub rather than ghcr

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # This Dockerfile is for generating the Metadata
 # and environment used for running the HUB.
-FROM ghcr.io/alphagov/verify/golang:1.15.5-alpine3.12 as golang
+FROM golang:1.16.4-alpine3.12 as golang
 
 RUN apk --no-cache upgrade && \
     apk add --no-cache build-base git &&\
     go get -u github.com/cloudflare/cfssl/cmd/...
 
-FROM ghcr.io/alphagov/verify/ruby:2.7.2-alpine3.12
+FROM ruby:2.7.2-alpine3.12
 
 RUN apk --no-cache upgrade && \
     apk add --no-cache build-base ncurses bash git openssl openjdk11 curl

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.8'
 
 services:
   redis:
-    image: ghcr.io/alphagov/verify/redis:6.0.9
+    image: redis:6.0.9
     volumes:
       - redis-data:/data
       - redis-config:/usr/local/etc/redis/
@@ -13,7 +13,7 @@ services:
       - hub-network
   
   stub-idp-db:
-    image: ghcr.io/alphagov/verify/postgres:12.5
+    image: postgres:12.5
     environment:
       POSTGRES_PASSWORD: docker
     volumes:
@@ -22,7 +22,7 @@ services:
       - hub-network
   
   metadata:
-    image: ghcr.io/alphagov/verify/nginx:latest
+    image: nginx:latest
     ports:
       - "${METADATA_EXTERNAL_PORT}:80"
     volumes:


### PR DESCRIPTION
We're no longer using github container registry and are now using docker
hub again.

Signed-off-by: Chris Mills <7100370+chriscoffee@users.noreply.github.com>