### PR TITLE
BAU: Allow use of preinstalled xmlsectool

### DIFF
--- a/generate/generate-metadata.sh
+++ b/generate/generate-metadata.sh
@@ -13,7 +13,7 @@ mkdir -p "$sources/compliance-tool/idps"
 rm -f "$output/*"
 
 # Test for XMLSectool requried to sign the XML
-if [ ! -f $XMLSECTOOL ]; then
+if ! command -v "$xmlsectool" &> /dev/null; then
   echo "XMLSecTool is required to run this script.  You can get XMLSecTool from:"
   echo "https://shibboleth.net/downloads/tools/xmlsectool/latest/xmlsectool-3.0.0-bin.zip"
   exit 1
@@ -57,7 +57,7 @@ for src in dev compliance-tool; do
   
   # sign
   echo "$(tput setaf 3)Signing metadata$(tput sgr0)"
-  $XMLSECTOOL \
+  $xmlsectool \
     --sign \
     --inFile "$output"/$src/metadata.xml \
     --outFile "$output"/$src/metadata.signed.xml \


### PR DESCRIPTION
This updates the generate-metadata script to correctly test if
xmlsectool is already installed and use it, if the XMLSECTOOL env
variable isn't set.

This allows you to run the script locally, not in a container where the
env var is set for you.