### PR TITLE
BAU: Allow using SNAPSHOTS in maven local

### DIFF
--- a/lib/image_builder.rb
+++ b/lib/image_builder.rb
@@ -2,6 +2,9 @@
 require 'os'
 require 'tty-spinner'
 require 'colorize'
+require 'fileutils'
+require 'tempfile'
+require 'securerandom'
 
 # This is our worker thread which builds our docker images
 class ImageBuilder
@@ -19,22 +22,33 @@ class ImageBuilder
       @write_success_log = write_success_log
       @output = "Starting build of #{repo_name}...\n"
     end
-  
+
     def build_image
       image_name = "#{@repo_name}:local"
       build_args = @config.fetch('build-args', []).map { |ba| "--build-arg #{ba.keys[0]}=#{ba.values[0]}" }.join " "
+      random_namespace = SecureRandom.hex # To prevent race conditions with separate threads
+      temp_m2_dirname = "m2_#{random_namespace}"
+      temp_dockerfile = "Dockerfile_#{random_namespace}"
+      dockerfile_content = insert_maven_local_copy_in_dockerfile(
+        "../#{@config['context']}/#{@config.fetch('dockerfile', 'Dockerfile')}",
+        temp_m2_dirname
+      )
+      File.open("../#{@config['context']}/#{temp_dockerfile}", 'w') { |f| f.write dockerfile_content }
+      FileUtils.cp_r "#{`realpath ~`.strip}/.m2/repository/uk/gov/ida/.", "../#{@config['context']}/#{temp_m2_dirname}"
       cmd = "docker build #{build_args}\
           --build-arg release=#{@release}\
           ../#{@config['context']}\
-          -f ../#{@config['context']}/#{@config.fetch('dockerfile', 'Dockerfile')}\
+          -f ../#{@config['context']}/#{temp_dockerfile}\
           -t #{image_name}\
           2>&1"
       output = `#{cmd}`
+      FileUtils.rm_rf("../#{@config['context']}/#{temp_m2_dirname}")
+      FileUtils.rm_rf("../#{@config['context']}/#{temp_dockerfile}")
       if $?.success?
         if @write_success_log
           @spinner.success(" - see #{@script_dir}/logs/#{@repo_name}_build.log")
           @output = @output + output + "\nBuild failed... Unable to retry.\n" 
-          File.write("#{@script_dir}/logs/#{@repo_name}_build.log", "log from command=#{cmd}\n#{output}", mode: "w")
+          File.write("#{@script_dir}/../logs/#{@repo_name}_build.log", "log from command=#{cmd}\n#{output}", mode: "w")
         else
           @spinner.success
         end
@@ -46,7 +60,7 @@ class ImageBuilder
         build_image
       else
         @output = @output + output + "\nBuild failed... Unable to retry.\n" 
-        File.write("#{@script_dir}/logs/#{@repo_name}_build.log", "log from command=#{cmd}\n#{output}", mode: "w")
+        File.write("#{@script_dir}/../logs/#{@repo_name}_build.log", "log from command=#{cmd}\n#{output}", mode: "w")
         @spinner.error(" - see #{@script_dir}/logs/#{@repo_name}_build.log")
         @success = false
       end
@@ -65,6 +79,20 @@ class ImageBuilder
   
     def success?
       return @success
+    end
+
+    def insert_maven_local_copy_in_dockerfile(dockerfile_path, m2_dir)
+      output = ""
+      dockerfile = File.new(dockerfile_path)
+      dockerfile.each do |line|
+        if line.start_with? 'WORKDIR' # We need the maven local repo available in each stage of the build
+          output << line
+          output << "COPY #{m2_dir}/ /root/.m2/repository/uk/gov/ida/\n"
+        else
+          output << line
+        end
+      end
+      output
     end
   end
   

--- a/lib/image_builder.rb
+++ b/lib/image_builder.rb
@@ -40,7 +40,7 @@ class ImageBuilder
 
       if success
         if @write_success_log
-          @spinner.success(" - see #{@script_dir}/logs/#{@repo_name}_build.log")
+          @spinner.success(" - see #{@script_dir}/../logs/#{@repo_name}_build.log")
           @output = @output + output + "\nBuild failed... Unable to retry.\n" 
           File.write("#{@script_dir}/../logs/#{@repo_name}_build.log", "log from command=#{cmd}\n#{output}", mode: "w")
         else
@@ -55,7 +55,7 @@ class ImageBuilder
       else
         @output = @output + output + "\nBuild failed... Unable to retry.\n" 
         File.write("#{@script_dir}/../logs/#{@repo_name}_build.log", "log from command=#{cmd}\n#{output}", mode: "w")
-        @spinner.error(" - see #{@script_dir}/logs/#{@repo_name}_build.log")
+        @spinner.error(" - see #{@script_dir}/../logs/#{@repo_name}_build.log")
         @success = false
       end
     end

--- a/startup.sh
+++ b/startup.sh
@@ -62,6 +62,8 @@ Usage:
     -b, --skip-build            Allows you to skip the build process.  Useful if you've
                                 already built everything and your developing something.
     -R, --rebuild-data          Tells the script to remove and rebuild the data directory.
+    -i, --include-maven-local   Copy your local maven directory to the Docker images. Allows
+                                you to use SNAPSHOTs of our libraries in the build.
     
   Dozzle (useful on Linux):
     -d, --dozzle                Run Dozzle for docker output viewing on port 50999.
@@ -89,41 +91,44 @@ YAML_FILE=repos.yml
 DOZZLE=false
 DOZZLEPORT=50999
 WRITE_BUILD_LOG=''
+INCLUDE_MAVEN_LOCAL=''
 
 while [ "$1" != "" ]; do
     case $1 in
-        -y | --yaml-file)       shift
-                                YAML_FILE=$1
-                                ;;
-        -t | --threads)         shift
-                                THREADS=$1
-                                ;;
-        -r | --retry-build)     shift
-                                RETRIES=$1
-                                ;;
-        -b | --skip-build)      SKIP_BUILD=true
-                                ;;
-        -w | --write-build-log) WRITE_BUILD_LOG='-w'
-                                ;;
-        -d | --dozzle)          DOZZLE=true
-                                ;;
-        -p | --dozzleport)      shift
-                                DOZZLEPORT=$1
-                                ;;
-        -R | --rebuild-data)    REBUILD_DATA=true
-                                ;;
-        -c | --clean)           CLEAN=true
-                                ;;
-        -s | --skip-data-check) SKIP_DATA_CHECK=true
-                                ;;
-        -h | --help)            show_help
-                                exit 0
-                                ;;
-        -g | --generate-only)   GENERATE_ONLY=true
-                                ;;
-        * )                     echo -e "Unknown option $1...\n"
-                                usage
-                                exit 1
+        -y | --yaml-file)            shift
+                                     YAML_FILE=$1
+                                     ;;
+        -t | --threads)              shift
+                                     THREADS=$1
+                                     ;;
+        -r | --retry-build)          shift
+                                     RETRIES=$1
+                                     ;;
+        -b | --skip-build)           SKIP_BUILD=true
+                                     ;;
+        -w | --write-build-log)      WRITE_BUILD_LOG='-w'
+                                     ;;
+        -d | --dozzle)               DOZZLE=true
+                                     ;;
+        -p | --dozzleport)           shift
+                                     DOZZLEPORT=$1
+                                     ;;
+        -R | --rebuild-data)         REBUILD_DATA=true
+                                     ;;
+        -c | --clean)                CLEAN=true
+                                     ;;
+        -s | --skip-data-check)      SKIP_DATA_CHECK=true
+                                     ;;
+        -h | --help)                 show_help
+                                     exit 0
+                                     ;;
+        -g | --generate-only)        GENERATE_ONLY=true
+                                     ;;
+        -i | --include-maven-local)  INCLUDE_MAVEN_LOCAL='-i'
+                                     ;;
+        * )                          echo -e "Unknown option $1...\n"
+                                     usage
+                                     exit 1
     esac
     shift
 done
@@ -193,7 +198,7 @@ fi
 
 if [[ $SKIP_BUILD == 'false' ]]; then
   bundle check || bundle install
-  bundle exec ./lib/build-local.rb -R $RETRIES -y $YAML_FILE -t $THREADS $WRITE_BUILD_LOG
+  bundle exec ./lib/build-local.rb -R $RETRIES -y $YAML_FILE -t $THREADS $WRITE_BUILD_LOG $INCLUDE_MAVEN_LOCAL
 else
   echo "Skipping build process..."
 fi


### PR DESCRIPTION
Often when developing the hub we want to use a snapshot of another
dependency, which has been published to your local maven repo.

This change makes your local maven repo available in the docker builds.
It copies the repo with a namespace to avoid issues with multiple
threads.

It adds `COPY` lines to the Dockerfile on the fly, rather than having to
maintain a separate Dockerfile.

I have no idea if this works with Linux so thoughts more than welcome.