### PR TITLE
BAU Fix critical bugs in local-startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # This Dockerfile is for generating the Metadata
 # and environment used for running the HUB.
-FROM golang:1.16.4-alpine3.12 as golang
+FROM golang:1.15.15-alpine3.13 as golang
 
 RUN apk --no-cache upgrade && \
     apk add --no-cache build-base git &&\
     go get -u github.com/cloudflare/cfssl/cmd/...
 
-FROM ruby:2.7.2-alpine3.12
+FROM ruby:2.7.3-alpine3.13
 
 RUN apk --no-cache upgrade && \
     apk add --no-cache build-base ncurses bash git openssl openjdk11 curl

--- a/lib/image_builder.rb
+++ b/lib/image_builder.rb
@@ -34,7 +34,7 @@ class ImageBuilder
         if @write_success_log
           @spinner.success(" - see #{@script_dir}/logs/#{@repo_name}_build.log")
           @output = @output + output + "\nBuild failed... Unable to retry.\n" 
-          File.write("#{@script_dir}/logs/#{@repo_name}_build.log", "log from command=#{cmd}\n#{output}", mode: "w")
+          File.write("#{@script_dir}/../logs/#{@repo_name}_build.log", "log from command=#{cmd}\n#{output}", mode: "w")
         else
           @spinner.success
         end


### PR DESCRIPTION
This commit fixes two critical bugs in verify-local-startup.  These are:

* The recent change in to the Dockerfile to Go 16 causes one of the
  components to fail to build.  Fix: Switched back to using Go 15 fixes
  the issue
* When a build fails or logging was turned on the build would fail
  because lib/logs didn't exist.  Fix: updated the path to point to the
  original log directory logs/