### PR TITLE
Fix for issue #89 success on fail bug

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,4 +7,5 @@ group :development do
   gem 'tty-spinner'
   gem 'os'
   gem 'colorize'
+  gem 'concurrent-ruby'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,6 +49,7 @@ PLATFORMS
 DEPENDENCIES
   OptionParser
   colorize
+  concurrent-ruby
   dotenv
   os
   tty-spinner

--- a/components.sh
+++ b/components.sh
@@ -14,7 +14,9 @@ Usage:
     -rb, --rebuild               Forces rebuilding of a compoent
                                  NOTE: This removes and rebuilds a component it will also
                                        restart the component if it was running at the time.
-                                       
+
+    -v,  --enbable-logging       Enable logging... logs will be written to logs/components.sh
+
     -h,  --help                  Show's this help message
 EOF
 }
@@ -44,6 +46,8 @@ while [ "$1" != "" ]; do
                                 shift
                                 COMPONENT=$1
                                 ;;
+        -v  | --enable-logging) ENABLE_LOGGING='-v'
+                                ;;
         -h  | --help)           show_help
                                 exit 0
                                 ;;
@@ -60,12 +64,12 @@ if [[ $? != 0 ]]; then
 fi
 
 case $ACTION in
-    list)       bundle exec ./lib/components.rb -l ;;
-    start)      bundle exec ./lib/components.rb -s $COMPONENT ;;
-    restart)    bundle exec ./lib/components.rb -r $COMPONENT ;;
-    stop)       bundle exec ./lib/components.rb -S $COMPONENT ;;
-    remove)     bundle exec ./lib/components.rb -rm $COMPONENT ;;
-    rebuild)    bundle exec ./lib/components.rb -rb $COMPONENT ;;
+    list)       bundle exec ./lib/components.rb -l $ENABLE_LOGGING;;
+    start)      bundle exec ./lib/components.rb -s $COMPONENT $ENABLE_LOGGING;;
+    restart)    bundle exec ./lib/components.rb -r $COMPONENT $ENABLE_LOGGING;;
+    stop)       bundle exec ./lib/components.rb -S $COMPONENT $ENABLE_LOGGING;;
+    remove)     bundle exec ./lib/components.rb -rm $COMPONENT $ENABLE_LOGGING;;
+    rebuild)    bundle exec ./lib/components.rb -rb $COMPONENT $ENABLE_LOGGING;;
     *)          show_help
                 exit 0
 esac

--- a/lib/logger.rb
+++ b/lib/logger.rb
@@ -1,0 +1,38 @@
+require 'logger'
+
+class Logger
+  # Creates or opens a secondary log file.
+  def attach(name)
+    @logdev.attach(name)
+  end
+
+  # Closes a secondary log file.
+  def detach(name)
+    @logdev.detach(name)
+  end
+
+  class LogDevice # :nodoc:
+    attr_reader :devs
+
+    def attach(log)
+      @devs ||= {}
+      @devs[log] = open_logfile(log)
+    end
+
+    def detach(log)
+      @devs ||= {}
+      @devs[log].close
+      @devs.delete(log)
+    end
+
+    alias_method :old_write, :write
+    def write(message)
+      old_write(message)
+
+      @devs ||= {}
+      @devs.each do |log, dev|
+        dev.write(message)
+      end
+    end
+  end
+end

--- a/startup.sh
+++ b/startup.sh
@@ -92,6 +92,7 @@ DOZZLE=false
 DOZZLEPORT=50999
 WRITE_BUILD_LOG=''
 INCLUDE_MAVEN_LOCAL=''
+ENABLE_BUILD_LOG=''
 
 while [ "$1" != "" ]; do
     case $1 in
@@ -126,8 +127,10 @@ while [ "$1" != "" ]; do
                                      ;;
         -i | --include-maven-local)  INCLUDE_MAVEN_LOCAL='-i'
                                      ;;
+        -v | --enable-logging)       ENABLE_BUILD_LOG='-v'
+                                     ;;
         * )                          echo -e "Unknown option $1...\n"
-                                     usage
+                                     show_help
                                      exit 1
     esac
     shift
@@ -144,7 +147,6 @@ esac
 
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 
-# Build a docker image with all of our dependencies for future steps
 if ! command -v docker >/dev/null; then
   >&2 echo "docker: command not found. verify-local-startup requires docker."
   exit 1
@@ -183,7 +185,7 @@ fi
 
 # Running generate scripts in docker avoids having to install their
 # dependencies on the host.
-docker build -t verify-local-startup .
+docker build -t verify-local-startup . > /dev/null
 docker run -t -v "$script_dir:/verify-local-startup/" verify-local-startup "
 set -e
 $REMOVE_DATA_DIR
@@ -198,7 +200,7 @@ fi
 
 if [[ $SKIP_BUILD == 'false' ]]; then
   bundle check || bundle install
-  bundle exec ./lib/build-local.rb -R $RETRIES -y $YAML_FILE -t $THREADS $WRITE_BUILD_LOG $INCLUDE_MAVEN_LOCAL
+  bundle exec ./lib/build-local.rb -R $RETRIES -y $YAML_FILE -t $THREADS $WRITE_BUILD_LOG $INCLUDE_MAVEN_LOCAL $ENABLE_BUILD_LOG
 else
   echo "Skipping build process..."
 fi


### PR DESCRIPTION
This is quite a far reaching PR as it fixes a couple of bugs and introduces logging in to the build-local ruby script and associate
components.  The bugs which are fixed are:

* Success of Fail bug (issue #89) - where the script would report a successful build on a component despite the actual command failing
* Correctly report number physical cpus when assigning the default number of threads.  This is now set to the maximum phyical cpu count. (unreported but known) 
* Fixes the components script which was broken with the introduction of the mavel build option. (unreported but known) 