### PR TITLE
BAU Fix for using posix /dev/null for null device

### DIFF
--- a/lib/build-local.rb
+++ b/lib/build-local.rb
@@ -54,7 +54,7 @@ SUCCESS_MARK = "🎆 🎉 ✅ 🎉 🎆"
 ERROR_MARK = "❌ 😡 ❌ 😡 ❌"
 
 # Setup Logger
-LOGGER = Logger.new('/dev/null')
+LOGGER = Logger.new(File::NULL)
 LOGGER.level = Logger::INFO
 
 def fetch_git_repos(thread_count, repos, write_success_log)

--- a/lib/components.rb
+++ b/lib/components.rb
@@ -39,7 +39,7 @@ SUCCESS_MARK = "🎆 🎉 ✅ 🎉 🎆"
 ERROR_MARK = "❌ 😡 ❌ 😡 ❌"
 
 # Setup Logger
-LOGGER = Logger.new('/dev/null')
+LOGGER = Logger.new(File::NULL)
 LOGGER.level = Logger::INFO
 
 def docker_ps


### PR DESCRIPTION
The use of /dev/null is good for Linux and Mac systems but its bad for Windows.  So I have updated the reference to /dev/null to point to File::NULL instead.  Which is platform independent.