### PR TITLE
BAU - Uplift golang to 1.19.0 to fix local startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 # This Dockerfile is for generating the Metadata
 # and environment used for running the HUB.
-FROM golang:1.15.15-alpine3.13 as golang
+FROM golang:1.19.0-alpine3.16 as golang
 
 RUN apk --no-cache upgrade && \
     apk add --no-cache build-base git &&\
-    go get -u github.com/cloudflare/cfssl/cmd/...
+    go install github.com/cloudflare/cfssl/cmd/...
 
 FROM ruby:2.7.3-alpine3.13
 


### PR DESCRIPTION
- Cloudflare cfssl now requires Go 1.16+ to build otherwise verify-local-startup does not work
- 'Go get' has been deprecated and we should now use 'Go install'